### PR TITLE
Add boolean return value to onEachEvent block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 3.0.0 - 2023.11.20
 
-### Changed
+### Breaking change
 
-- `LiveData.onEachEvent` block expects a Boolean result value. This will control whether the event is marked as handled or not. This is useful when the event is received in a state where the action can't be handled. 
+- `LiveData.onEachEvent` block expects a Boolean result value. This will control whether the event is marked as handled or not. This is useful when the event is received in a state where the action can't be handled. Return `true` to keep the previous behaviour.
 
 ## 2.1.0 - 2023.07.25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project does not use semantic versioning.
 
+## 3.0.0 - 2023.11.20
+
+### Changed
+
+- `LiveData.onEachEvent` block expects a Boolean result value. This will control whether the event is marked as handled or not. This is useful when the event is received in a state where the action can't be handled. 
+
 ## 2.1.0 - 2023.07.25
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ ext {
     targetSdk = 33
 
     // Current version of the library
-    libraryVersion = "2.1.1"
+    libraryVersion = "3.0.0"
 }
 
 buildscript {
@@ -22,7 +22,7 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
     }
-    ext.kotlinVersion = '1.9.0'
+    ext.kotlinVersion = '1.9.10'
     // NB! Make sure to update the kltint version set in the root build.gradle file. subprojects / ktlint / version
     // NB! ktlint-gradle doesn't always depend on the latest ktlint version, but since it is a thin wrapper around ktlint
     // NB! it can be usefult to use a newer version of ktlint to get ruleset updates, etc.
@@ -36,7 +36,7 @@ buildscript {
     ext.savedStateVersion = '2.2.0'
     ext.fragmentVersion = '1.6.0'
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlintGradleVersion"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detectGradleVersion"

--- a/mvvm-sample/src/main/java/mobi/lab/mvvmsample/main/MainActivity.kt
+++ b/mvvm-sample/src/main/java/mobi/lab/mvvmsample/main/MainActivity.kt
@@ -25,6 +25,7 @@ class MainActivity : AppCompatActivity(R.layout.main), MvvmLiveDataExtensions {
             if (action is MainViewModel.Action.OpenSecondScreen) {
                 startActivity(Intent(this, SecondActivity::class.java))
             }
+            return@onEachEvent true
         }
     }
 }

--- a/mvvm-sample/src/main/java/mobi/lab/mvvmsample/second/SecondFragment.kt
+++ b/mvvm-sample/src/main/java/mobi/lab/mvvmsample/second/SecondFragment.kt
@@ -1,5 +1,6 @@
 package mobi.lab.mvvmsample.second
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -47,19 +48,24 @@ class SecondFragment : Fragment(R.layout.fragment_second), MvvmLiveDataExtension
             }
         }
         viewModel.action.onEachEvent { action ->
-            when (action) {
-                is SecondViewModel.Action.ShowConfirmCoolDialog -> showConfirmCoolDialog()
-                is SecondViewModel.Action.ShowConfirmNotCoolDialog -> showConfirmNotCoolDialog()
+            val context = context
+            if (context == null) {
+                return@onEachEvent false
             }
+            when (action) {
+                is SecondViewModel.Action.ShowConfirmCoolDialog -> showConfirmCoolDialog(context)
+                is SecondViewModel.Action.ShowConfirmNotCoolDialog -> showConfirmNotCoolDialog(context)
+            }
+            return@onEachEvent true
         }
     }
 
-    private fun showConfirmCoolDialog() {
-        Toast.makeText(activity, getString(R.string.text_cool), Toast.LENGTH_SHORT).show()
+    private fun showConfirmCoolDialog(context: Context) {
+        Toast.makeText(context, getString(R.string.text_cool), Toast.LENGTH_SHORT).show()
     }
 
-    private fun showConfirmNotCoolDialog() {
-        Toast.makeText(activity, getString(R.string.text_not_cool), Toast.LENGTH_SHORT).show()
+    private fun showConfirmNotCoolDialog(context: Context) {
+        Toast.makeText(context, getString(R.string.text_not_cool), Toast.LENGTH_SHORT).show()
     }
 
     companion object {

--- a/mvvm/src/main/java/mobi/lab/mvvm/MvvmLiveDataExtensions.kt
+++ b/mvvm/src/main/java/mobi/lab/mvvm/MvvmLiveDataExtensions.kt
@@ -16,7 +16,7 @@ public interface MvvmLiveDataExtensions {
     }
 
     @Suppress("UNCHECKED_CAST")
-    public fun <T, E : SingleEvent<T>> LiveData<E>.onEachEvent(block: (T) -> Unit) {
+    public fun <T, E : SingleEvent<T>> LiveData<E>.onEachEvent(block: (T) -> Boolean) {
         this.observe(getLifecycleOwner(), SingleEventObserver<T> { block(it) } as Observer<E>)
     }
 }

--- a/mvvm/src/main/java/mobi/lab/mvvm/SingleEventObserver.kt
+++ b/mvvm/src/main/java/mobi/lab/mvvm/SingleEventObserver.kt
@@ -8,10 +8,15 @@ import androidx.lifecycle.Observer
  *
  * [onEventUnhandledContent] is *only* called if the [SingleEvent]'s contents has not been handled.
  */
-public class SingleEventObserver<T>(private val unhandledContentObserver: (T) -> Unit) : Observer<SingleEvent<T>> {
+public class SingleEventObserver<T>(private val unhandledContentObserver: (T) -> Boolean) : Observer<SingleEvent<T>> {
     override fun onChanged(event: SingleEvent<T>?) {
-        event?.getContentIfNotHandled()?.let { value ->
-            unhandledContentObserver.invoke(value)
+        if (event == null || event.hasBeenHandled) {
+            return
+        }
+
+        if (unhandledContentObserver.invoke(event.peekContent())) {
+            // Mark as handled
+            event.getContentIfNotHandled()
         }
     }
 }


### PR DESCRIPTION
Return a boolean from LiveData.onEachEvent handler. 

The return will be handled as follows:
* true - mark the event as handled
* false - keep the event as not handled

This makes the process more explicit. In most cases, Context based navigation is the result of an event. Since LiveData.observe() is active in at least STARTED state, Context should always be there. 

In any case, adding the return value here makes the decision more explicit and makes it easier to know corner cases are handled, too
